### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 7.1
   - 7.2
+  - 7.3
 
 before_script:
   - composer install

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,6 @@
          convertWarningsToExceptions = "true"
          processIsolation            = "false"
          stopOnFailure               = "false"
-         syntaxCheck                 = "false"
          bootstrap                   = "test/bootstrap.php">
 
     <testsuites>

--- a/test/ArrayKeysTest.php
+++ b/test/ArrayKeysTest.php
@@ -11,16 +11,12 @@ class ArrayKeysTest extends TestCase
 
     public function testToSnakeCaseCallShouldWork() : void
     {
-        ArrayKeys::toSnakeCase([]);
-
-        $this->assertTrue(true);
+        $this->assertSame([], ArrayKeys::toSnakeCase([]));
     }
 
     public function testToCamelCaseCallShouldWork() : void
     {
-        ArrayKeys::toCamelCase([]);
-
-        $this->assertTrue(true);
+        $this->assertSame([], ArrayKeys::toCamelCase([]));
     }
 
     public function testTransformCallShouldWork() : void
@@ -32,8 +28,6 @@ class ArrayKeysTest extends TestCase
             }
         };
 
-        ArrayKeys::transform($converter, []);
-
-        $this->assertTrue(true);
+        $this->assertSame([], ArrayKeys::transform($converter, []));
     }
 }

--- a/test/Transformer/ToCamelCaseTest.php
+++ b/test/Transformer/ToCamelCaseTest.php
@@ -15,6 +15,7 @@ class ToCamelCaseTest extends TestCase
             'second item' => 'Second Item',
             'third-item'  => 'Third Item',
             'fourthItem'  => 'Fourth Item',
+            'arrayValueItem'  => ['Array Value Item'],
         ];
 
         $arrayExpected = [
@@ -22,6 +23,7 @@ class ToCamelCaseTest extends TestCase
             'secondItem' => 'Second Item',
             'thirdItem'  => 'Third Item',
             'fourthItem' => 'Fourth Item',
+            'arrayValueItem'  => ['Array Value Item'],
         ];
 
         $result = (new ToCamelCase())->transform($arrayToBeTested);

--- a/test/Transformer/ToSnakeCaseTest.php
+++ b/test/Transformer/ToSnakeCaseTest.php
@@ -15,6 +15,7 @@ class ToSnakeCaseTest extends TestCase
             'second item' => 'Second Item',
             'third-item'  => 'Third Item',
             'fourth_item' => 'Fourth Item',
+            'arrayValueItem'  => ['Array Value Item'],
         ];
 
         $arrayExpected = [
@@ -22,6 +23,7 @@ class ToSnakeCaseTest extends TestCase
             'second_item' => 'Second Item',
             'third_item'  => 'Third Item',
             'fourth_item' => 'Fourth Item',
+            'array_value_item'  => ['Array Value Item'],
         ];
 
         $result = (new ToSnakeCase())->transform($arrayToBeTested);


### PR DESCRIPTION
# Changed log
- Add `php-7.3` test in Travis CI build because it's stable version now.
- Remove `syntaxCheck` attribute because this attribute is deprecated in `PHPUnit 7.x version`.
- Let the result value assert the expected is empty array.
- Add the test case about key with array value to check `ToCamelCase` and `ToSnakeCalse` classes can handle this.