### PR TITLE
Fix test classes name-spaces to be compatible with PSR-4

### DIFF
--- a/test/Transformer/ToCamelCaseTest.php
+++ b/test/Transformer/ToCamelCaseTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\ArrayKeysCaseTransform\Transformer;
+namespace Tests\Transformer;
 
 use ArrayKeysCaseTransform\Transformer\ToCamelCase;
 use PHPUnit\Framework\TestCase;

--- a/test/Transformer/ToSnakeCaseTest.php
+++ b/test/Transformer/ToSnakeCaseTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\ArrayKeysCaseTransform\Transformer;
+namespace Tests\Transformer;
 
 use ArrayKeysCaseTransform\Transformer\ToSnakeCase;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
To solve

```bash
Deprecation Notice: Class Tests\ArrayKeysCaseTransform\Transformer\ToCamelCaseTest located in ./vendor/deoliveiralucas/array-keys-case-transform/test/Transformer/ToCamelCaseTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/local/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Tests\ArrayKeysCaseTransform\Transformer\ToSnakeCaseTest located in ./vendor/deoliveiralucas/array-keys-case-transform/test/Transformer/ToSnakeCaseTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/local/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
```